### PR TITLE
CW1173: generic fixes

### DIFF
--- a/lib/coins/bitcoin/creation/common.dart
+++ b/lib/coins/bitcoin/creation/common.dart
@@ -48,7 +48,19 @@ class BitcoinWalletCreation extends WalletCreation {
     isExtra: true,
   );
 
-  late List<FormElement> createForm = [passphrase];
+  late StringFormElement passphraseConfirm = StringFormElement(
+    L.wallet_passphrase,
+    password: false,
+    validator: nonEmptyValidator(
+      L,
+      extra: (final input) => input != passphrase.ctrl.text ? L.seed_passphrase_mismatch : null,
+    ),
+    errorHandler: errorHandler,
+    canPaste: true,
+    isExtra: true,
+  );
+
+  late List<FormElement> createForm = [passphrase, passphraseConfirm];
   late List<FormElement> restoreForm = [seed, passphrase];
 
   @override
@@ -57,6 +69,11 @@ class BitcoinWalletCreation extends WalletCreation {
     final String walletName,
     final String walletPassword,
   ) async {
+    if (createMethod == CreateMethod.create) {
+      if (await passphrase.value != await passphraseConfirm.value) {
+        throw Exception(L.seed_passphrase_mismatch);
+      }
+    }
     return switch (createMethod) {
       CreateMethod.create => CreateBitcoinWalletCreationMethod(
           L,

--- a/lib/coins/bitcoin/wallet.dart
+++ b/lib/coins/bitcoin/wallet.dart
@@ -186,13 +186,13 @@ class BitcoinWallet implements CoinWallet {
     return [
       WalletSeedDetail(
         type: WalletSeedDetailType.text,
-        name: "Seed",
+        name: Coin.L.seed,
         value: seed,
       ),
       if (passphrase.isNotEmpty)
         WalletSeedDetail(
           type: WalletSeedDetailType.text,
-          name: "Passphrase",
+          name: Coin.L.wallet_passphrase,
           value: passphrase,
         ),
       WalletSeedDetail(
@@ -202,7 +202,7 @@ class BitcoinWallet implements CoinWallet {
       ),
       WalletSeedDetail(
         type: WalletSeedDetailType.qr,
-        name: "Pair Cake Wallet",
+        name: Coin.L.view_only_restore_qr,
         value: publicUri.toString(),
       ),
     ];

--- a/lib/coins/monero/wallet.dart
+++ b/lib/coins/monero/wallet.dart
@@ -240,12 +240,6 @@ class MoneroWallet implements CoinWallet {
         name: Coin.L.seed_screen_wallet_seed_legacy,
         value: legacySeed,
       ),
-      if (seedOffset.isNotEmpty)
-        WalletSeedDetail(
-          type: WalletSeedDetailType.text,
-          name: Coin.L.seed_offset,
-          value: seedOffset,
-        ),
       WalletSeedDetail(
         type: WalletSeedDetailType.text,
         name: Coin.L.view_key,
@@ -271,6 +265,12 @@ class MoneroWallet implements CoinWallet {
         name: Coin.L.restore_height,
         value: wallet.getRefreshFromBlockHeight().toString(),
       ),
+      if (passphrase.isNotEmpty)
+        WalletSeedDetail(
+          type: WalletSeedDetailType.text,
+          name: Coin.L.wallet_passphrase,
+          value: passphrase,
+        ),
       WalletSeedDetail(
         type: WalletSeedDetailType.qr,
         name: Coin.L.view_only_restore_qr,
@@ -280,6 +280,7 @@ class MoneroWallet implements CoinWallet {
   }
 
   String get pairQrString => const JsonEncoder.withIndent('   ').convert({
+        "label": p.basename(walletName),
         "version": 0,
         "primaryAddress": primaryAddress,
         "privateViewKey": wallet.secretViewKey(),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -64,6 +64,7 @@
   "invalid_password": "Invalid password",
   "keys": "Keys",
   "link_to_cakewallet": "Link to Cake Wallet",
+  "need_use_cakewallet": "**Welcome to Cupcake!**\nCupcake lets you store and manage your crypto even more securely, turning any old phone into a hardware wallet at a tap. Cupcake uses QR codes to communicate with Cake Wallet, ensuring that your keys never leave your offline Cupcake app. While you can receive and view transactions at any time in Cake Wallet after pairing, you’ll need Cupcake to sign any transactions you want to send. Maximum security, minimum effort.",
   "next": "Next",
   "no_seed_available": "No seed is available",
   "opening_wallet": "Opening wallet",

--- a/lib/utils/form/flutter_secure_storage_value_outcome.dart
+++ b/lib/utils/form/flutter_secure_storage_value_outcome.dart
@@ -32,7 +32,10 @@ class FlutterSecureStorageValueOutcome implements ValueOutcome {
       );
     }
     if (sha512Hash.toString() != valInput && verifyMatching) {
-      throw Exception("Input doesn't match the secure element value");
+      if (CupcakeConfig.instance.debug) {
+        throw Exception("Input doesn't match the secure element value");
+      }
+      throw Exception("Invalid password");
     }
 
     final input_ = await secureStorage.read(key: key);

--- a/lib/utils/form/pin_form_element.dart
+++ b/lib/utils/form/pin_form_element.dart
@@ -86,7 +86,12 @@ abstract class PinFormElementBase extends FormElement with Store {
 
   @action
   Future<void> onConfirmInternal(final BuildContext context) async {
-    await valueOutcome.encode(ctrl.text);
+    try {
+      await valueOutcome.encode(ctrl.text);
+    } catch (e) {
+      await clear();
+      rethrow;
+    }
     isConfirmed = true;
   }
 

--- a/lib/utils/new_wallet/info_page.dart
+++ b/lib/utils/new_wallet/info_page.dart
@@ -11,7 +11,6 @@ import 'package:cupcake/views/widgets/seed_grid.dart';
 import 'package:cupcake/views/widgets/yellow_warning.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 
 class NewWalletInfoPage {
   NewWalletInfoPage({
@@ -21,7 +20,37 @@ class NewWalletInfoPage {
     required this.svgIcon,
     required this.actions,
     required this.texts,
+    this.popAnimation = true,
   });
+
+  final bool popAnimation;
+
+  static NewWalletInfoPage needUseCakeWallet(final AppLocalizations L, final ThemeData T) =>
+      NewWalletInfoPage(
+        topText: L.important,
+        topAction: null,
+        topActionText: null,
+        svgIcon: Assets.icons.linkCakewallet.image(),
+        actions: [
+          NewWalletAction(
+            type: NewWalletActionType.nextPage,
+            function: null,
+            text: L.next,
+          ),
+        ],
+        texts: [
+          SizedBox(height: 24),
+          Text.rich(
+            markdownText(L.need_use_cakewallet),
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: T.colorScheme.onSurface,
+              fontSize: 16,
+            ),
+          ),
+        ],
+      );
+
   static NewWalletInfoPage preShowSeedPage(final AppLocalizations L, final ThemeData T) =>
       NewWalletInfoPage(
         topText: L.important,
@@ -72,7 +101,7 @@ class NewWalletInfoPage {
                 final isCorrect = await VerifySeedPage(
                   seedWords: text.split(" "),
                   wordList: Bip39.english,
-                ).push(context);
+                ).pushWithoutAnimation(context);
                 if (isCorrect != true) return;
               }
               nextPage();
@@ -107,6 +136,7 @@ class NewWalletInfoPage {
     required final Future<void> Function()? nextCallback,
   }) =>
       NewWalletInfoPage(
+        popAnimation: false,
         topText: L.verify_seed,
         topAction: null,
         topActionText: null,
@@ -142,7 +172,7 @@ class NewWalletInfoPage {
   final VoidCallback? topAction;
   final Widget? topActionText;
 
-  final SvgPicture? svgIcon;
+  final Widget? svgIcon;
   final List<NewWalletAction> actions;
 
   List<Widget> texts;

--- a/lib/view_model/create_wallet_view_model.dart
+++ b/lib/view_model/create_wallet_view_model.dart
@@ -288,6 +288,7 @@ abstract class CreateWalletViewModelBase extends ViewModel with Store {
     }
 
     final List<NewWalletInfoPage> pages = [
+      NewWalletInfoPage.needUseCakeWallet(L, T),
       NewWalletInfoPage.preShowSeedPage(L, T),
       NewWalletInfoPage.writeDownNotice(
         L,

--- a/lib/view_model/new_wallet_info_view_model.dart
+++ b/lib/view_model/new_wallet_info_view_model.dart
@@ -18,7 +18,11 @@ abstract class NewWalletInfoViewModelBase extends ViewModel with Store {
 
   void nextPage() {
     final nextPageIndex = (currentPageIndex + 1) % pages.length;
-    NewWalletInfoScreen(pages: pages, currentPageIndex: nextPageIndex).push(c!);
+    if (pages[nextPageIndex].popAnimation) {
+      NewWalletInfoScreen(pages: pages, currentPageIndex: nextPageIndex).push(c!);
+    } else {
+      NewWalletInfoScreen(pages: pages, currentPageIndex: nextPageIndex).pushWithoutAnimation(c!);
+    }
   }
 
   final int currentPageIndex;

--- a/lib/views/abstract.dart
+++ b/lib/views/abstract.dart
@@ -78,6 +78,25 @@ class AbstractView extends StatefulWidget {
     );
   }
 
+  Future<dynamic> pushWithoutAnimation(final BuildContext context) {
+    Widget builder(final context) {
+      return this;
+    }
+
+    return Navigator.of(context).push(
+      PageRouteBuilder(
+        pageBuilder: (
+          final BuildContext context,
+          final Animation<double> animation,
+          final Animation<double> secondaryAnimation,
+        ) =>
+            builder(context),
+        transitionDuration: Duration.zero,
+        reverseTransitionDuration: Duration.zero,
+      ),
+    );
+  }
+
   final ViewModel viewModel = ViewModelSimple();
 
   @override

--- a/lib/views/create_wallet.dart
+++ b/lib/views/create_wallet.dart
@@ -51,57 +51,63 @@ class CreateWallet extends AbstractView {
   }
 
   Widget _createMethodKind(final BuildContext context) {
-    return SingleChildScrollView(
-      child: SafeArea(
-        top: false,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            SizedBox(height: 32),
-            SizedBox.square(
-              dimension: 250,
-              child: Assets.icons.walletNew.image(),
-            ),
-            // Spacer(),
-            Padding(
-              padding: const EdgeInsets.all(42.0),
-              child: Text.rich(
-                markdownText(L.wallet_creation_onboard),
-                style: TextStyle(color: T.colorScheme.onSurface, fontSize: 16),
-                textAlign: TextAlign.center,
+    return Column(
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            child: SafeArea(
+              top: false,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  SizedBox(height: 32),
+                  SizedBox.square(
+                    dimension: 250,
+                    child: Assets.icons.walletNew.image(),
+                  ),
+                  // Spacer(),
+                  Padding(
+                    padding: const EdgeInsets.all(42.0),
+                    child: Text.rich(
+                      markdownText(L.wallet_creation_onboard),
+                      style: TextStyle(color: T.colorScheme.onSurface, fontSize: 16),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                  // Spacer(),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 86.0),
+                    child: Text(
+                      L.wallet_creation_kind_note,
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                  SizedBox(
+                    height: 16,
+                  ),
+                ],
               ),
             ),
-            // Spacer(),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 86.0),
-              child: Text(
-                L.wallet_creation_kind_note,
-                textAlign: TextAlign.center,
-              ),
-            ),
-            SizedBox(
-              height: 16,
-            ),
-            LongSecondaryButton(
-              T,
-              onPressed: () async {
-                await CreateWallet(
-                  viewModel: viewModel.copyWith(newCreateMethod: CreateMethod.restore),
-                ).pushReplacement(context);
-              },
-              text: L.restore_wallet,
-            ),
-            LongPrimaryButton(
-              onPressed: () async {
-                await CreateWallet(
-                  viewModel: viewModel.copyWith(newCreateMethod: CreateMethod.create),
-                ).pushReplacement(context);
-              },
-              text: L.create_new_wallet,
-            ),
-          ],
+          ),
         ),
-      ),
+        LongSecondaryButton(
+          T,
+          onPressed: () async {
+            await CreateWallet(
+              viewModel: viewModel.copyWith(newCreateMethod: CreateMethod.restore),
+            ).pushReplacement(context);
+          },
+          text: L.restore_wallet,
+        ),
+        LongPrimaryButton(
+          onPressed: () async {
+            await CreateWallet(
+              viewModel: viewModel.copyWith(newCreateMethod: CreateMethod.create),
+            ).pushReplacement(context);
+          },
+          text: L.create_new_wallet,
+        ),
+      ],
     );
   }
 
@@ -109,7 +115,7 @@ class CreateWallet extends AbstractView {
   Widget body(final BuildContext context) {
     return Observer(
       builder: (final BuildContext context) {
-        return _body(context) ?? const SizedBox.shrink();
+        return SafeArea(child: _body(context) ?? const SizedBox.shrink());
       },
     );
   }

--- a/lib/views/ui_playground.dart
+++ b/lib/views/ui_playground.dart
@@ -144,6 +144,11 @@ class UIPlayground extends AbstractView {
               NewWalletInfoPage.preShowSeedPage(L, T),
             ],
           ).push(context),
+      "NewWalletInfoScreen(needUseCakeWallet)": () => NewWalletInfoScreen(
+            pages: [
+              NewWalletInfoPage.needUseCakeWallet(L, T),
+            ],
+          ).push(context),
       "NewWalletInfoScreen(writeDownNotice)": () => NewWalletInfoScreen(
             pages: [
               NewWalletInfoPage.writeDownNotice(

--- a/lib/views/wallet_edit.dart
+++ b/lib/views/wallet_edit.dart
@@ -110,10 +110,11 @@ class WalletEdit {
             showExtra: true,
             viewModel: viewModel.formBuilderViewModel,
           ),
-          SizedBox(
-            height: 280,
-          ),
           bottomNavigationBar(context),
+          if (MediaQuery.of(context).viewInsets.bottom > 0)
+            SizedBox(
+              height: 280,
+            ),
         ],
       ),
     );


### PR DESCRIPTION
I’ve captured a few bug fixes and enhancements from testing here that I didn’t want to forget or get lost in Slack while I’m on leave:

 - [x] We should send the wallet name via the “Link to Cake Wallet” QR code by default, and process that in Cake Wallet so the two match
 - [x] If Editing a wallet requires PIN (as it seems to?) we should prompt for PIN before showing the edit wallet bottom sheet, similar to how we do on the seed and keys screen
 - [x] Currently it prompts for “Wallet password” (which I don’t have) and then errors out if I provide my PIN there so it’s hard to test what is actually required here
 - [x] Fix massive whitespace on “Edit wallet” bottom sheet
 - [x] Verifying seed does this weird “pop through” thing where when I tap a seed word it pops through the seed phrase screen for a split second before showing the next seed word to verify
 - [x] Add new explainer screen after hitting continue
 - [x] Add passphrase confirmation box
 - [x] Right now users only get a single entry field for passphrase, should also have a confirmation secondary field like Cake Wallet has.
 - [x] Clear PIN on failed entry
 - [x] Right now the failed PIN remains, making it require manually deleting the entered PIN entirely before you can retry the PIN
 - [ ] Improve about screen with links and simple explainer
    - Can I get UI draft?
 - [ ] Clarify “outputs (all)” toggle
   - It is made clear when user needs to click it in error message in cake wallet

